### PR TITLE
增强在移动端的兼容性；调整部分实现细节，使连续播放两个素材时中间没有空隙成为可能；修改素材元素时可以复用原有素材的尺寸

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svga-web",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A SVGA player for modern Web.",
   "homepage": "https://github.com/Naeemo/svga-web",
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,25 @@ import Player from './player'
 import DB from './db'
 import VideoEntity from './parser/video-entity'
 
+/* Safari and Edge polyfill for createImageBitmap
+ * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap
+ */
+if (!('createImageBitmap' in window)) {
+    window.createImageBitmap = async function(blob) {
+        return new Promise((resolve,reject) => {
+            let img = document.createElement('img');
+            img.addEventListener('load', function() {
+                resolve(this as any);
+            });
+            img.addEventListener('error', function(e) {
+                // console.log('createImageBitmap error', e);
+                reject(e);
+            })
+            img.src = URL.createObjectURL(blob as any);
+        });
+    }
+}
+
 export * from './parser'
 export * from './player'
 export * from './db'

--- a/src/parser/video-entity.ts
+++ b/src/parser/video-entity.ts
@@ -8,7 +8,7 @@ export interface VideoSize {
 }
 
 export interface ImageSources {
-  [key: string]: CanvasImageSource
+  [key: string]: CanvasImageSource|ArrayBuffer
 }
 
 interface AudioSource extends svga.AudioEntity {

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -133,10 +133,7 @@ export default class Player {
   public mount(videoItem: VideoEntity): Promise<void> {
     this.currentFrame = 0
     this.videoItem = videoItem
-
-    const prepare = this.renderer.prepare(videoItem)
-    this.renderer.clear()
-    return prepare
+    return this.renderer.prepare(videoItem)
   }
 
   public start(): void {

--- a/src/player/offscreen.canvas.render.ts
+++ b/src/player/offscreen.canvas.render.ts
@@ -45,7 +45,11 @@ function render(
         })
         context.clip()
       }
-      context.drawImage(img, 0, 0)
+      if (img instanceof Image) {
+        context.drawImage(img, 0, 0, img.width, img.height)
+      } else {
+        context.drawImage(img, 0, 0)
+      }
     }
 
     const dynamicElement = sprite.imageKey && dynamicElements[sprite.imageKey]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import path from 'path'
 
 export default defineConfig({
   build: {
+    minify: true, // false for facilitate debug
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
       name: 'SVGA',


### PR DESCRIPTION
fix: window.createImageBitmap 不兼容iOS老版本
fix: 使用替换元素时，没有办法复用之前的元素的尺寸
将调用 mount 后会进行清屏改为不请屏，外层业务需要清屏功能可以手动调用 clear